### PR TITLE
ViewNotifier Implementierung

### DIFF
--- a/Implementierung/src/main/java/de/sswis/controller/ViewNotifier.java
+++ b/Implementierung/src/main/java/de/sswis/controller/ViewNotifier.java
@@ -3,6 +3,8 @@ package de.sswis.controller;
 import de.sswis.model.Simulation;
 import de.sswis.view.AbstractMainView;
 
+import javax.swing.*;
+
 /**
  * Benachrichtigt die View über beendete {@code Simulationen}. Wird eine Simulation beendet benachrichtigt dieser
  * {@code SimulationObserver} die View. Dazu wird die entsprechende {@code Simulation} im Hauptfenster als
@@ -24,6 +26,6 @@ public class ViewNotifier implements SimulationObserver {
 
     @Override
     public void update(Simulation sim) {
-        this.mainView.setSimulationFinished(sim.getName());
+        SwingUtilities.invokeLater(() -> mainView.setSimulationFinished(sim.getName()));
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/ViewNotifier.java
+++ b/Implementierung/src/main/java/de/sswis/controller/ViewNotifier.java
@@ -19,11 +19,11 @@ public class ViewNotifier implements SimulationObserver {
      * @param mainView das Hauptfenster, das benachrichtigt wird
      */
     public ViewNotifier(AbstractMainView mainView) {
-
+        this.mainView = mainView;
     }
 
     @Override
     public void update(Simulation sim) {
-
+        this.mainView.setSimulationFinished(sim.getName());
     }
 }

--- a/Implementierung/src/main/java/de/sswis/model/Simulation.java
+++ b/Implementierung/src/main/java/de/sswis/model/Simulation.java
@@ -86,7 +86,7 @@ public class Simulation implements Runnable, ObservableSimulation {
      * @see Configuration#getName()
      */
     public String getName() {
-        return null;
+        return this.config.getName();
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/Simulation.java
+++ b/Implementierung/src/main/java/de/sswis/model/Simulation.java
@@ -79,6 +79,16 @@ public class Simulation implements Runnable, ObservableSimulation {
 
     }
 
+    /**
+     * Liefert den Namen der Simulation zurück. Der Name ist identisch zum Namen der zugehörigen
+     * {@code Configuration}.
+     * @return der Name der Simulation
+     * @see Configuration#getName()
+     */
+    public String getName() {
+        return null;
+    }
+
     @Override
     public void run() {
 


### PR DESCRIPTION
Bei der Simulation musste noch eine getName Methode hinzugefügt werden. Name ist identisch zur zugehörigen Konfiguration (alternative wäre sim.getConfiguration().getName() gewesen).