### PR TITLE
Konstruktor aus Strategy entfernt

### DIFF
--- a/Implementierung/src/main/java/de/sswis/model/Strategy.java
+++ b/Implementierung/src/main/java/de/sswis/model/Strategy.java
@@ -12,10 +12,6 @@ public interface Strategy {
      */
     String getName();
 
-    public Strategy(String name, CombinedStrategy[] combinedStrategies, double[] probabilities) {
-        this.name = name;
-    }
-
     /**
      * Berechnet die Aktion des Agenten um dessen Strategie es sich handelt im Spiel mit einem zweiten Agenten.
      * @param agent1 Agent


### PR DESCRIPTION
Ich habe beim mergen ausversehen den Konstruktor zum Strategy Interface hinzugefügt. Konstruktor wurde jetzte wieder entfernt.