### PR TITLE
Handler bugfixes

### DIFF
--- a/Implementierung/src/main/java/de/sswis/controller/FileManager.java
+++ b/Implementierung/src/main/java/de/sswis/controller/FileManager.java
@@ -24,15 +24,15 @@ public class FileManager {
 
     private Gson gson;
 
-    public static final String BASE_PATH            = "src/main/resources/saves";
+    private static final String BASE_PATH            = "src/main/resources/saves";
 
-    public static final String VM_CONFIGURATION     = "VMConfiguration";
-    public static final String VM_INITIALIZATION    = "VMInitialization";
-    public static final String VM_GAME              = "VMGame";
-    public static final String VM_COMBINED_STRATEGY = "VMCombinedStrategy";
-    public static final String VM_RESULT            = "VMResult";
-    public static final String VM_STRATEGY          = "VMStrategy";
-    public static final String JSON_EXTENSION       = ".json";
+    private static final String VM_CONFIGURATION     = "VMConfiguration";
+    private static final String VM_INITIALIZATION    = "VMInitialization";
+    private static final String VM_GAME              = "VMGame";
+    private static final String VM_COMBINED_STRATEGY = "VMCombinedStrategy";
+    private static final String VM_RESULT            = "VMResult";
+    private static final String VM_STRATEGY          = "VMStrategy";
+    private static final String JSON_EXTENSION       = ".json";
 
     /**
      * Standardkonstruktor
@@ -41,29 +41,30 @@ public class FileManager {
         this.gson = new GsonBuilder().create();
     }
 
+    private File[] getFilesInSaves() {
+        File dir = new File(FileManager.BASE_PATH);
+        return dir.listFiles();
+    }
+
     /**
      * Lädt alle vorhandenen {@code VMConfiguration} Objekte.
      *
      * @return eine {@code Collection} von {@code VMConfigurations}
      */
     public Collection<VMConfiguration> loadAllConfigurations() {
-        File dir = new File(FileManager.BASE_PATH);
-        File[] filesInDir = dir.listFiles();
-        ArrayList<VMConfiguration> configurations = new ArrayList<>();
+        File[] filesInDir = this.getFilesInSaves();
+        assert filesInDir != null;
 
+        ArrayList<VMConfiguration> configurations = new ArrayList<>();
         for (File file : filesInDir) {
             if (file.isDirectory())
                 continue;
             if (file.getName().startsWith(FileManager.VM_CONFIGURATION)) {
-                JsonReader reader = null;
-                try {
-                    reader = new JsonReader(new FileReader(file));
-                } catch (FileNotFoundException e) {
-                    // this exception should never occur, if it doesn't exist it shouldn't have been loaded
-                    // in dir.listFiles()
+                try (JsonReader reader = new JsonReader(new FileReader(file))) {
+                    configurations.add(this.loadConfiguration(reader));
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
-                configurations.add(this.loadConfiguration(reader));
             }
         }
         return configurations;
@@ -75,21 +76,19 @@ public class FileManager {
      * @return eine {@code Collection} von {@code VMGame}
      */
     public Collection<VMGame> loadAllGames() {
-        File dir = new File(FileManager.BASE_PATH);
-        File[] filesInDir = dir.listFiles();
-        ArrayList<VMGame> games = new ArrayList<>();
+        File[] filesInDir = this.getFilesInSaves();
+        assert filesInDir != null;
 
+        ArrayList<VMGame> games = new ArrayList<>();
         for (File file : filesInDir) {
             if (file.isDirectory())
                 continue;
             if (file.getName().startsWith(FileManager.VM_GAME)) {
-                JsonReader reader = null;
-                try {
-                    reader = new JsonReader(new FileReader(file));
-                } catch (FileNotFoundException e) {
+                try (JsonReader reader = new JsonReader(new FileReader(file))) {
+                    games.add(this.loadGame(reader));
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
-                games.add(this.loadGame(reader));
             }
         }
         return games;
@@ -101,21 +100,19 @@ public class FileManager {
      * @return eine {@code Collection} von {@code VMInitialization}
      */
     public Collection<VMInitialization> loadAllInitializations() {
-        File dir = new File(FileManager.BASE_PATH);
-        File[] filesInDir = dir.listFiles();
-        ArrayList<VMInitialization> initializations = new ArrayList<>();
+        File[] filesInDir = this.getFilesInSaves();
+        assert filesInDir != null;
 
+        ArrayList<VMInitialization> initializations = new ArrayList<>();
         for (File file : filesInDir) {
             if (file.isDirectory())
                 continue;
             if (file.getName().startsWith(FileManager.VM_INITIALIZATION)) {
-                JsonReader reader = null;
-                try {
-                    reader = new JsonReader(new FileReader(file));
-                } catch (FileNotFoundException e) {
+                try (JsonReader reader = new JsonReader(new FileReader(file))) {
+                    initializations.add(this.loadInitialization(reader));
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
-                initializations.add(this.loadInitialization(reader));
             }
         }
         return initializations;
@@ -127,21 +124,19 @@ public class FileManager {
      * @return eine {@code Collection} von {@code VMCombinedStrategy}
      */
     public Collection<VMCombinedStrategy> loadAllCombinedStrategies() {
-        File dir = new File(FileManager.BASE_PATH);
-        File[] filesInDir = dir.listFiles();
-        ArrayList<VMCombinedStrategy> combinedStrategies = new ArrayList<>();
+        File[] filesInDir = this.getFilesInSaves();
+        assert filesInDir != null;
 
+        ArrayList<VMCombinedStrategy> combinedStrategies = new ArrayList<>();
         for (File file : filesInDir) {
             if (file.isDirectory())
                 continue;
             if (file.getName().startsWith(FileManager.VM_COMBINED_STRATEGY)) {
-                JsonReader reader = null;
-                try {
-                    reader = new JsonReader(new FileReader(file));
-                } catch (FileNotFoundException e) {
+                try (JsonReader reader = new JsonReader(new FileReader(file))) {
+                    combinedStrategies.add(this.loadCombinedStrategy(reader));
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
-                combinedStrategies.add(this.loadCombinedStrategy(reader));
             }
         }
         return combinedStrategies;
@@ -152,22 +147,20 @@ public class FileManager {
      *
      * @return eine {@code Collection} von {@code VMStartegy}
      */
-    public Collection<VMStrategy> loadAllMixedStrageyies() {
-        File dir = new File(FileManager.BASE_PATH);
-        File[] filesInDir = dir.listFiles();
-        ArrayList<VMStrategy> mixedStrategies = new ArrayList<>();
+    public Collection<VMStrategy> loadAllMixedStrategies() {
+        File[] filesInDir = this.getFilesInSaves();
+        assert filesInDir != null;
 
+        ArrayList<VMStrategy> mixedStrategies = new ArrayList<>();
         for (File file : filesInDir) {
             if (file.isDirectory())
                 continue;
             if (file.getName().startsWith(FileManager.VM_STRATEGY)) {
-                JsonReader reader = null;
-                try {
-                    reader = new JsonReader(new FileReader(file));
-                } catch (FileNotFoundException e) {
+                try (JsonReader reader = new JsonReader(new FileReader(file))) {
+                    mixedStrategies.add(this.loadMixedStrategy(reader));
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
-                mixedStrategies.add(this.loadMixedStrategy(reader));
             }
         }
         return mixedStrategies;
@@ -179,21 +172,19 @@ public class FileManager {
      * @return eine {@code Collection} von {@code VMResult}
      */
     public Collection<VMResult> loadAllResults() {
-        File dir = new File(FileManager.BASE_PATH);
-        File[] filesInDir = dir.listFiles();
-        ArrayList<VMResult> results = new ArrayList<>();
+        File[] filesInDir = this.getFilesInSaves();
+        assert filesInDir != null;
 
+        ArrayList<VMResult> results = new ArrayList<>();
         for (File file : filesInDir) {
             if (file.isDirectory())
                 continue;
             if (file.getName().startsWith(FileManager.VM_RESULT)) {
-                JsonReader reader = null;
-                try {
-                    reader = new JsonReader(new FileReader(file));
-                } catch (FileNotFoundException e) {
+                try (JsonReader reader = new JsonReader(new FileReader(file))) {
+                    results.add(this.loadResult(reader));
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
-                results.add(this.loadResult(reader));
             }
         }
         return results;
@@ -231,7 +222,7 @@ public class FileManager {
      * @param initialization die zu speichernde {@code VMInitialization}
      */
     public void saveInitialization(VMInitialization initialization) throws IOException {
-        deleteInitalization(initialization.getName());
+        deleteInitialization(initialization.getName());
         String filePath = this.getFilePath(FileManager.VM_INITIALIZATION, initialization.getName());
         try (Writer writer = new FileWriter(filePath)) {
             this.gson.toJson(initialization, writer);
@@ -286,8 +277,12 @@ public class FileManager {
      */
     public VMConfiguration loadConfiguration(String name) throws FileNotFoundException {
         String filePath = this.getFilePath(FileManager.VM_CONFIGURATION, name);
-        JsonReader jsonReader = new JsonReader(new FileReader(filePath));
-        return this.loadConfiguration(jsonReader);
+        try (JsonReader jsonReader = new JsonReader(new FileReader(filePath))) {
+            return this.loadConfiguration(jsonReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private VMConfiguration loadConfiguration(JsonReader reader) {
@@ -303,8 +298,12 @@ public class FileManager {
      */
     public VMGame loadGame(String name) throws FileNotFoundException {
         String filePath = this.getFilePath(FileManager.VM_GAME, name);
-        JsonReader jsonReader = new JsonReader(new FileReader(filePath));
-        return this.loadGame(jsonReader);
+        try (JsonReader jsonReader = new JsonReader(new FileReader(filePath))) {
+            return this.loadGame(jsonReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private VMGame loadGame(JsonReader reader) {
@@ -320,8 +319,12 @@ public class FileManager {
      */
     public VMInitialization loadInitialization(String name) throws FileNotFoundException {
         String filePath = this.getFilePath(FileManager.VM_INITIALIZATION, name);
-        JsonReader jsonReader = new JsonReader(new FileReader(filePath));
-        return this.loadInitialization(jsonReader);
+        try (JsonReader jsonReader = new JsonReader(new FileReader(filePath))) {
+            return this.loadInitialization(jsonReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private VMInitialization loadInitialization(JsonReader reader) {
@@ -337,8 +340,12 @@ public class FileManager {
      */
     public VMCombinedStrategy loadCombinedStrategy(String name) throws FileNotFoundException {
         String filePath = this.getFilePath(FileManager.VM_COMBINED_STRATEGY, name);
-        JsonReader jsonReader = new JsonReader(new FileReader(filePath));
-        return this.loadCombinedStrategy(jsonReader);
+        try (JsonReader jsonReader = new JsonReader(new FileReader(filePath))) {
+            return this.loadCombinedStrategy(jsonReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private VMCombinedStrategy loadCombinedStrategy(JsonReader reader) {
@@ -354,8 +361,12 @@ public class FileManager {
      */
     public VMStrategy loadMixedStrategy(String name) throws FileNotFoundException {
         String filePath = this.getFilePath(FileManager.VM_STRATEGY, name);
-        JsonReader jsonReader = new JsonReader(new FileReader(filePath));
-        return this.loadMixedStrategy(jsonReader);
+        try (JsonReader jsonReader = new JsonReader(new FileReader(filePath))) {
+            return this.loadMixedStrategy(jsonReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private VMStrategy loadMixedStrategy(JsonReader reader) {
@@ -371,8 +382,12 @@ public class FileManager {
      */
     public VMResult loadResult(String name) throws FileNotFoundException {
         String filePath = this.getFilePath(FileManager.VM_RESULT, name);
-        JsonReader jsonReader = new JsonReader(new FileReader(filePath));
-        return this.loadResult(jsonReader);
+        try (JsonReader jsonReader = new JsonReader(new FileReader(filePath))) {
+            return this.loadResult(jsonReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private VMResult loadResult(JsonReader reader) {
@@ -407,7 +422,7 @@ public class FileManager {
      *
      * @param name der Name der {@code VMInitialisation}
      */
-    public void deleteInitalization(String name) throws IOException {
+    public void deleteInitialization(String name) throws IOException {
         Path path = Paths.get(this.getFilePath(FileManager.VM_INITIALIZATION, name));
         Files.deleteIfExists(path);
     }

--- a/Implementierung/src/main/java/de/sswis/controller/Sswis.java
+++ b/Implementierung/src/main/java/de/sswis/controller/Sswis.java
@@ -29,7 +29,7 @@ public class Sswis {
             provider.addCombinedStrategy(combinedStrategy);
         }
 
-        Collection<VMStrategy> vmStrategies = fileManager.loadAllMixedStrageyies();
+        Collection<VMStrategy> vmStrategies = fileManager.loadAllMixedStrategies();
         for (VMStrategy s : vmStrategies) {
             MixedStrategy strategy = parser.parseVMStrategy(s);
             provider.addMixedStrategy(strategy);

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/DeleteInitializationHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/DeleteInitializationHandler.java
@@ -31,7 +31,7 @@ public class DeleteInitializationHandler implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         VMInitialization selectedVM = this.manageInitializationsView.getSelectedVM();
         try {
-            this.fileManager.deleteInitalization(selectedVM.getName());
+            this.fileManager.deleteInitialization(selectedVM.getName());
         } catch (IOException e1) {
             e1.printStackTrace();
             return;

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/EditCombinedStrategyHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/EditCombinedStrategyHandler.java
@@ -40,6 +40,9 @@ public class EditCombinedStrategyHandler implements ActionListener {
         newCombinedStrategyView.setParentView(manageCombinedStrategiesView);
         VMCombinedStrategy selectedVM = this.manageCombinedStrategiesView.getSelectedVM();
         newCombinedStrategyView.setCombinedStrategy(selectedVM);
+        VMCombinedStrategy editedCombinedStrategy = new VMCombinedStrategy();
+        editedCombinedStrategy.setName(selectedVM.getName());
+        manageCombinedStrategiesView.setEditedCombinedStrategy(editedCombinedStrategy);
         for(Condition c : this.serviceLoader.getConditionList()) {
             newCombinedStrategyView.addCondition(c.getName());
             HashMap<String, String[]> parameters = new HashMap<>();

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/EditConfigurationHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/EditConfigurationHandler.java
@@ -45,6 +45,9 @@ public class EditConfigurationHandler implements ActionListener {
         newConfigurationView.setParentView(this.manageConfigurationsView);
         VMConfiguration selectedVM = this.manageConfigurationsView.getSelectedVM();
         newConfigurationView.setConfiguration(selectedVM);
+        VMConfiguration editedConfiguration = new VMConfiguration();
+        editedConfiguration.setName(selectedVM.getName());
+        manageConfigurationsView.setEditedConfiguration(editedConfiguration);
         for (AdaptationAlgorithm a : this.serviceLoader.getAdaptAlgorithmList()) {
             newConfigurationView.addAdaptionAlgorithm(a.getName());
             HashMap<String, String[]> parameters = new HashMap<>();

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/EditGameHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/EditGameHandler.java
@@ -32,6 +32,9 @@ public class EditGameHandler implements ActionListener {
         AbstractNewGameView newGameView = this.factory.createNewGameView();
         newGameView.setParentView(manageGamesView);
         VMGame selectedVM = this.manageGamesView.getSelectedVM();
+        VMGame editedGame = new VMGame();
+        editedGame.setName(selectedVM.getName());
+        this.manageGamesView.setEditedGame(editedGame);
         newGameView.setGame(selectedVM);
         newGameView.show();
     }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/EditInitializationHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/EditInitializationHandler.java
@@ -37,6 +37,9 @@ public class EditInitializationHandler implements ActionListener {
         newInitializationView.setParentView(this.manageInitializationsView);
         VMInitialization selectedVM = this.manageInitializationsView.getSelectedVM();
         newInitializationView.setInitialization(selectedVM);
+        VMInitialization editedInitialization = new VMInitialization();
+        editedInitialization.setName(selectedVM.getName());
+        manageInitializationsView.setEditedInitialization(editedInitialization);
         for (VMCombinedStrategy c : this.fileManager.loadAllCombinedStrategies()) {
             newInitializationView.addCombinedStrategy(c.getName());
         }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/EditStrategyHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/EditStrategyHandler.java
@@ -40,6 +40,9 @@ public class EditStrategyHandler implements ActionListener {
         newStrategyView.setParentView(this.manageStrategiesView);
         VMStrategy selectedVM = this.manageStrategiesView.getSelectedVM();
         newStrategyView.setStrategy(selectedVM);
+        VMStrategy editedStrategy = new VMStrategy();
+        editedStrategy.setName(selectedVM.getName());
+        manageStrategiesView.setEditedStrategy(editedStrategy);
         for (VMCombinedStrategy c : this.fileManager.loadAllCombinedStrategies()) {
             newStrategyView.addCombinedStrategy(c.getName());
         }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/ManageStrategiesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/ManageStrategiesHandler.java
@@ -34,7 +34,7 @@ public class ManageStrategiesHandler implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         AbstractManageStrategiesView manageStrategiesView = this.factory.createManageStrategiesView();
         manageStrategiesView.setParentView(mainView);
-        for(VMStrategy s : this.fileManager.loadAllMixedStrageyies()) {
+        for(VMStrategy s : this.fileManager.loadAllMixedStrategies()) {
             manageStrategiesView.addStrategy(s);
         }
         manageStrategiesView.show();

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveCombinedStrategiesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveCombinedStrategiesHandler.java
@@ -52,6 +52,20 @@ public class SaveCombinedStrategiesHandler implements ActionListener {
         if (parentView == null) {
             return;
         }
-        parentView.addStrategy(combinedStrategy);
+        VMCombinedStrategy editedCombinedStrategy = parentView.getEditedCombinedStrategy();
+        if (editedCombinedStrategy == null) {
+            parentView.addStrategy(combinedStrategy);
+        } else {
+            parentView.replaceCombinedStrategy(combinedStrategy);
+            if (!editedCombinedStrategy.getName().equals(combinedStrategy.getName())) {
+                ModelProvider.getInstance().deleteCombinedStrategy(editedCombinedStrategy.getName());
+                try {
+                    this.fileManager.deleteCombinedStrategy(editedCombinedStrategy.getName());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+            parentView.setEditedCombinedStrategy(null);
+        }
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveCombinedStrategiesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveCombinedStrategiesHandler.java
@@ -48,9 +48,10 @@ public class SaveCombinedStrategiesHandler implements ActionListener {
         CombinedStrategy cs = this.parser.parseVMCombinedStrategy(combinedStrategy);
         ModelProvider.getInstance().addCombinedStrategy(cs);
         AbstractManageCombinedStrategiesView parentView = this.combinedStrategyView.getParentView();
-        if (parentView == null)
-            return;
-        parentView.addStrategy(combinedStrategy);
         this.combinedStrategyView.close();
+        if (parentView == null) {
+            return;
+        }
+        parentView.addStrategy(combinedStrategy);
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveConfigurationsHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveConfigurationsHandler.java
@@ -53,6 +53,20 @@ public class SaveConfigurationsHandler implements ActionListener {
         if (parentView == null) {
             return;
         }
-        parentView.addConfiguration(vmConfiguration);
+        VMConfiguration editedConfiguration = parentView.getEditedConfiguration();
+        if (editedConfiguration == null) {
+            parentView.addConfiguration(vmConfiguration);
+        } else {
+            parentView.replaceConfiguration(vmConfiguration);
+            if (!editedConfiguration.getName().equals(vmConfiguration.getName())) {
+                ModelProvider.getInstance().deleteConfiguration(editedConfiguration.getName());
+                try {
+                    this.fileManager.deleteConfiguration(editedConfiguration.getName());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+            parentView.setEditedConfiguration(null);
+        }
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveConfigurationsHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveConfigurationsHandler.java
@@ -49,9 +49,10 @@ public class SaveConfigurationsHandler implements ActionListener {
             ModelProvider.getInstance().addConfiguration(c);
         }
         AbstractManageConfigurationsView parentView = this.configurationView.getParentView();
-        if (parentView == null)
-            return;
-        parentView.addConfiguration(vmConfiguration);
         this.configurationView.close();
+        if (parentView == null) {
+            return;
+        }
+        parentView.addConfiguration(vmConfiguration);
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveGamesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveGamesHandler.java
@@ -62,8 +62,8 @@ public class SaveGamesHandler implements ActionListener {
                 } catch (IOException e1) {
                     e1.printStackTrace();
                 }
-                parentView.setEditedGame(null);
             }
+            parentView.setEditedGame(null);
         }
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveGamesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveGamesHandler.java
@@ -46,9 +46,10 @@ public class SaveGamesHandler implements ActionListener {
         Game game = this.parser.parseVMGame(vmGame);
         ModelProvider.getInstance().addGame(game);
         AbstractManageGamesView parentView = this.gameView.getParentView();
-        if (parentView == null)
-            return;
-        parentView.addGame(vmGame);
         this.gameView.close();
+        if (parentView == null) {
+            return;
+        }
+        parentView.addGame(vmGame);
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveGamesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveGamesHandler.java
@@ -50,6 +50,20 @@ public class SaveGamesHandler implements ActionListener {
         if (parentView == null) {
             return;
         }
-        parentView.addGame(vmGame);
+        VMGame editedGame = parentView.getEditedGame();
+        if (editedGame == null) {
+            parentView.addGame(vmGame);
+        } else {
+            parentView.replaceGame(vmGame);
+            if (!editedGame.getName().equals(vmGame.getName())) {
+                ModelProvider.getInstance().deleteGame(editedGame.getName());
+                try {
+                    this.fileManager.deleteGame(editedGame.getName());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+                parentView.setEditedGame(null);
+            }
+        }
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveInitializationsHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveInitializationsHandler.java
@@ -53,6 +53,20 @@ public class SaveInitializationsHandler implements ActionListener {
         if (parentView == null) {
             return;
         }
-        parentView.addInit(vmInitialization);
+        VMInitialization editedInitialization = parentView.getEditedInitialization();
+        if (editedInitialization == null) {
+            parentView.addInit(vmInitialization);
+        } else {
+            parentView.replaceInitialization(vmInitialization);
+            if (!editedInitialization.getName().equals(vmInitialization.getName())) {
+                ModelProvider.getInstance().deleteInitialization(editedInitialization.getName());
+                try {
+                    this.fileManager.deleteInitialization(editedInitialization.getName());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+            parentView.setEditedInitialization(null);
+        }
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveInitializationsHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveInitializationsHandler.java
@@ -49,9 +49,10 @@ public class SaveInitializationsHandler implements ActionListener {
             ModelProvider.getInstance().addInitialization(i);
         }
         AbstractManageInitializationsView parentView = this.initializationView.getParentView();
-        if (parentView == null)
-            return;
-        parentView.addInit(vmInitialization);
         this.initializationView.close();
+        if (parentView == null) {
+            return;
+        }
+        parentView.addInit(vmInitialization);
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveStrategiesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveStrategiesHandler.java
@@ -48,9 +48,10 @@ public class SaveStrategiesHandler implements ActionListener {
         ModelProvider.getInstance().addMixedStrategy(mixedStrategy);
 
         AbstractManageStrategiesView parentView = this.strategyView.getParentView();
-        if (parentView == null)
-            return;
-        parentView.addStrategy(vmStrategy);
         this.strategyView.close();
+        if (parentView == null) {
+            return;
+        }
+        parentView.addStrategy(vmStrategy);
     }
 }

--- a/Implementierung/src/main/java/de/sswis/controller/handlers/SaveStrategiesHandler.java
+++ b/Implementierung/src/main/java/de/sswis/controller/handlers/SaveStrategiesHandler.java
@@ -52,6 +52,20 @@ public class SaveStrategiesHandler implements ActionListener {
         if (parentView == null) {
             return;
         }
-        parentView.addStrategy(vmStrategy);
+        VMStrategy editedStrategy = parentView.getEditedStrategy();
+        if (editedStrategy == null) {
+            parentView.addStrategy(vmStrategy);
+        } else {
+            parentView.replaceStrategy(vmStrategy);
+            if (!editedStrategy.getName().equals(vmStrategy.getName())) {
+                ModelProvider.getInstance().deleteMixedStrategy(editedStrategy.getName());
+                try {
+                    this.fileManager.deleteMixedStrategy(editedStrategy.getName());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+            parentView.setEditedStrategy(null);
+        }
     }
 }

--- a/Implementierung/src/main/java/de/sswis/view/AbstractManageCombinedStrategiesView.java
+++ b/Implementierung/src/main/java/de/sswis/view/AbstractManageCombinedStrategiesView.java
@@ -57,4 +57,10 @@ public interface AbstractManageCombinedStrategiesView extends AbstractView {
     VMCombinedStrategy getSelectedVM();
 
     AbstractMainView getParentView();
+
+    void setEditedCombinedStrategy(VMCombinedStrategy vmCombinedStrategy);
+
+    VMCombinedStrategy getEditedCombinedStrategy();
+
+    void replaceCombinedStrategy(VMCombinedStrategy newCombinedStrategy);
 }

--- a/Implementierung/src/main/java/de/sswis/view/AbstractManageConfigurationsView.java
+++ b/Implementierung/src/main/java/de/sswis/view/AbstractManageConfigurationsView.java
@@ -58,4 +58,10 @@ public interface AbstractManageConfigurationsView extends AbstractView {
 
     AbstractMainView getParentView();
 
+    void setEditedConfiguration(VMConfiguration vmConfiguration);
+
+    VMConfiguration getEditedConfiguration();
+
+    void replaceConfiguration(VMConfiguration newConfiguration);
+
 }

--- a/Implementierung/src/main/java/de/sswis/view/AbstractManageGamesView.java
+++ b/Implementierung/src/main/java/de/sswis/view/AbstractManageGamesView.java
@@ -58,4 +58,9 @@ public interface AbstractManageGamesView extends AbstractView {
 
     AbstractMainView getParentView();
 
+    void setEditedGame(VMGame game);
+
+    VMGame getEditedGame();
+
+    void replaceGame(VMGame newGame);
 }

--- a/Implementierung/src/main/java/de/sswis/view/AbstractManageInitializationsView.java
+++ b/Implementierung/src/main/java/de/sswis/view/AbstractManageInitializationsView.java
@@ -58,4 +58,10 @@ public interface AbstractManageInitializationsView extends AbstractView {
 
     AbstractMainView getParentView();
 
+    void setEditedInitialization(VMInitialization initialization);
+
+    VMInitialization getEditedInitialization();
+
+    void replaceInitialization(VMInitialization newInitialization);
+
 }

--- a/Implementierung/src/main/java/de/sswis/view/AbstractManageStrategiesView.java
+++ b/Implementierung/src/main/java/de/sswis/view/AbstractManageStrategiesView.java
@@ -57,4 +57,11 @@ public interface AbstractManageStrategiesView extends AbstractView {
     VMStrategy getSelectedVM();
 
     AbstractMainView getParentView();
+
+    void setEditedStrategy(VMStrategy strategy);
+
+    VMStrategy getEditedStrategy();
+
+    void replaceStrategy(VMStrategy newStrategy);
+
 }

--- a/Implementierung/src/main/java/de/sswis/view/ManageCombinedStrategiesView.java
+++ b/Implementierung/src/main/java/de/sswis/view/ManageCombinedStrategiesView.java
@@ -38,6 +38,7 @@ public class ManageCombinedStrategiesView implements AbstractManageCombinedStrat
 
 
     private AbstractMainView parentView;
+    private VMCombinedStrategy editedCombinedStrategy;
 
     public ManageCombinedStrategiesView() {
         vmCombinedStrategies = new ArrayList<VMCombinedStrategy>();
@@ -58,6 +59,23 @@ public class ManageCombinedStrategiesView implements AbstractManageCombinedStrat
 
         update();
 
+    }
+
+    @Override
+    public void replaceCombinedStrategy(VMCombinedStrategy newCombinedStrategy) {
+        int index = StrategiesPane.getSelectedIndex();
+        vmCombinedStrategies.remove(index);
+        vmCombinedStrategies.add(index, newCombinedStrategy);
+
+        CombinedStrategyTab tab = new CombinedStrategyTab();
+        tab.setVMCombinedStrategy(newCombinedStrategy);
+        tab.addDeleteButtonActionlistener(deleteListener);
+        tab.addEditButtonActionlistener(editListener);
+
+        strategyTabs.remove(index);
+        strategyTabs.add(index, tab);
+        StrategiesPane.remove(index);
+        StrategiesPane.insertTab(newCombinedStrategy.getName(), null, tab.$$$getRootComponent$$$(), null, index);
     }
 
     @Override
@@ -139,6 +157,16 @@ public class ManageCombinedStrategiesView implements AbstractManageCombinedStrat
     @Override
     public AbstractMainView getParentView() {
         return this.parentView;
+    }
+
+    @Override
+    public void setEditedCombinedStrategy(VMCombinedStrategy vmCombinedStrategy) {
+        this.editedCombinedStrategy = vmCombinedStrategy;
+    }
+
+    @Override
+    public VMCombinedStrategy getEditedCombinedStrategy() {
+        return this.editedCombinedStrategy;
     }
 
 

--- a/Implementierung/src/main/java/de/sswis/view/ManageConfigurationsView.java
+++ b/Implementierung/src/main/java/de/sswis/view/ManageConfigurationsView.java
@@ -37,6 +37,7 @@ public class ManageConfigurationsView implements AbstractManageConfigurationsVie
     private JPanel MainPanel;
 
     private AbstractMainView parentView;
+    private VMConfiguration editedConfiguration;
 
     public ManageConfigurationsView() {
         vmConfigurations = new ArrayList<VMConfiguration>();
@@ -54,6 +55,23 @@ public class ManageConfigurationsView implements AbstractManageConfigurationsVie
         tab.addEditButtonActionlistener(editListener);
         configTabs.add(tab);
         ConfigurationsPane.addTab(configuration.getName(), tab.$$$getRootComponent$$$());
+    }
+
+    @Override
+    public void replaceConfiguration(VMConfiguration newConfiguration) {
+        int index = this.ConfigurationsPane.getSelectedIndex();
+        vmConfigurations.remove(index);
+        vmConfigurations.add(index, newConfiguration);
+
+        ConfigurationTab tab = new ConfigurationTab();
+        tab.setVmConfiguration(newConfiguration);
+        tab.addDeleteButtonActionlistener(deleteListener);
+        tab.addEditButtonActionlistener(editListener);
+
+        configTabs.remove(index);
+        configTabs.add(index, tab);
+        ConfigurationsPane.remove(index);
+        ConfigurationsPane.insertTab(newConfiguration.getName(), null, tab.$$$getRootComponent$$$(), null, index);
     }
 
 
@@ -129,6 +147,16 @@ public class ManageConfigurationsView implements AbstractManageConfigurationsVie
     @Override
     public AbstractMainView getParentView() {
         return this.parentView;
+    }
+
+    @Override
+    public void setEditedConfiguration(VMConfiguration vmConfiguration) {
+        this.editedConfiguration = vmConfiguration;
+    }
+
+    @Override
+    public VMConfiguration getEditedConfiguration() {
+        return this.editedConfiguration;
     }
 
 

--- a/Implementierung/src/main/java/de/sswis/view/ManageGamesView.java
+++ b/Implementierung/src/main/java/de/sswis/view/ManageGamesView.java
@@ -37,6 +37,7 @@ public class ManageGamesView implements AbstractManageGamesView {
     private JTabbedPane GamesPane;
 
     private AbstractMainView parentView;
+    private VMGame editedGame;
 
     public ManageGamesView() {
         vmGames = new ArrayList<VMGame>();
@@ -56,6 +57,23 @@ public class ManageGamesView implements AbstractManageGamesView {
         GamesPane.addTab(game.getName(), tab.$$$getRootComponent$$$());
     }
 
+
+    @Override
+    public void replaceGame(VMGame newGame) {
+        int index = GamesPane.getSelectedIndex();
+        vmGames.remove(index);
+        vmGames.add(index, newGame);
+
+        GameTab tab = new GameTab();
+        tab.setVmGame(newGame);
+        tab.addDeleteButtonActionlistener(deleteListener);
+        tab.addEditButtonActionlistener(editListener);
+
+        gameTabs.remove(index);
+        gameTabs.add(index, tab);
+        GamesPane.remove(index);
+        GamesPane.insertTab(newGame.getName(), null, tab.$$$getRootComponent$$$(), null, index);
+    }
 
     @Override
     public void removeGame(String gameName) {
@@ -131,6 +149,15 @@ public class ManageGamesView implements AbstractManageGamesView {
         return this.parentView;
     }
 
+    @Override
+    public void setEditedGame(VMGame game) {
+        this.editedGame = game;
+    }
+
+    @Override
+    public VMGame getEditedGame() {
+        return this.editedGame;
+    }
 
     private void createUIComponents() {
         // TODO: place custom component creation code here

--- a/Implementierung/src/main/java/de/sswis/view/ManageInitializationsView.java
+++ b/Implementierung/src/main/java/de/sswis/view/ManageInitializationsView.java
@@ -69,7 +69,7 @@ public class ManageInitializationsView implements AbstractManageInitializationsV
         initializationTabs.remove(index);
         initializationTabs.add(index, tab);
         InitsPane.remove(index);
-        InitsPane.insertTab(newInitialization.getName(),null, tab.$$$getRootComponent$$$(),null, index);
+        InitsPane.insertTab(newInitialization.getName(), null, tab.$$$getRootComponent$$$(), null, index);
     }
 
     @Override
@@ -204,4 +204,5 @@ public class ManageInitializationsView implements AbstractManageInitializationsV
     public JComponent $$$getRootComponent$$$() {
         return MainPanel;
     }
+
 }

--- a/Implementierung/src/main/java/de/sswis/view/ManageInitializationsView.java
+++ b/Implementierung/src/main/java/de/sswis/view/ManageInitializationsView.java
@@ -36,6 +36,7 @@ public class ManageInitializationsView implements AbstractManageInitializationsV
     private JPanel MainPanel;
 
     private AbstractMainView parentView;
+    private VMInitialization editedInitialization;
 
     public ManageInitializationsView() {
         vmInits = new ArrayList<VMInitialization>();
@@ -54,6 +55,22 @@ public class ManageInitializationsView implements AbstractManageInitializationsV
         InitsPane.addTab(vmInitialization.getName(), tab.$$$getRootComponent$$$());
     }
 
+    @Override
+    public void replaceInitialization(VMInitialization newInitialization) {
+        int index = this.InitsPane.getSelectedIndex();
+        vmInits.remove(index);
+        vmInits.add(index, newInitialization);
+
+        InitializationTab tab = new InitializationTab();
+        tab.setVmInitialization(newInitialization);
+        tab.addDeleteButtonActionlistener(deleteListener);
+        tab.addEditButtonActionlistener(editListener);
+
+        initializationTabs.remove(index);
+        initializationTabs.add(index, tab);
+        InitsPane.remove(index);
+        InitsPane.insertTab(newInitialization.getName(),null, tab.$$$getRootComponent$$$(),null, index);
+    }
 
     @Override
     public void removeInit(String initName) {
@@ -127,6 +144,16 @@ public class ManageInitializationsView implements AbstractManageInitializationsV
     @Override
     public AbstractMainView getParentView() {
         return this.parentView;
+    }
+
+    @Override
+    public void setEditedInitialization(VMInitialization initialization) {
+        this.editedInitialization = initialization;
+    }
+
+    @Override
+    public VMInitialization getEditedInitialization() {
+        return this.editedInitialization;
     }
 
 

--- a/Implementierung/src/main/java/de/sswis/view/ManageStrategiesView.java
+++ b/Implementierung/src/main/java/de/sswis/view/ManageStrategiesView.java
@@ -35,6 +35,7 @@ public class ManageStrategiesView implements AbstractManageStrategiesView {
     private JTabbedPane strategiesPane;
 
     private AbstractMainView parentView;
+    private VMStrategy editedStrategy;
 
     public ManageStrategiesView() {
         vmStrategies = new ArrayList<VMStrategy>();
@@ -53,6 +54,22 @@ public class ManageStrategiesView implements AbstractManageStrategiesView {
         strategiesPane.addTab(vmStrategy.getName(), tab.$$$getRootComponent$$$());
     }
 
+    @Override
+    public void replaceStrategy(VMStrategy newStrategy) {
+        int index = this.strategiesPane.getSelectedIndex();
+        vmStrategies.remove(index);
+        vmStrategies.add(index, newStrategy);
+
+        MixedStrategyTab tab = new MixedStrategyTab();
+        tab.setVmStrategy(newStrategy);
+        tab.addDeleteButtonActionlistener(deleteListener);
+        tab.addEditButtonActionlistener(editListener);
+
+        strategyTabs.remove(index);
+        strategyTabs.add(index, tab);
+        strategiesPane.remove(index);
+        strategiesPane.insertTab(newStrategy.getName(), null, tab.$$$getRootComponent$$$(), null, index);
+    }
 
     @Override
     public void removeStrategy(String strategyName) {
@@ -125,6 +142,16 @@ public class ManageStrategiesView implements AbstractManageStrategiesView {
     @Override
     public AbstractMainView getParentView() {
         return this.parentView;
+    }
+
+    @Override
+    public void setEditedStrategy(VMStrategy strategy) {
+        this.editedStrategy = strategy;
+    }
+
+    @Override
+    public VMStrategy getEditedStrategy() {
+        return this.editedStrategy;
     }
 
 


### PR DESCRIPTION
Es wurden drei Bugs behoben.

1: Beim Löschen der .json Dateien ist eine Exception aufgetreten, da die JsonReader nach dem Schreiben nicht geschlossen wurden.

2: Der Edit Button in den ManageViews hat nicht so funktioniert wie erwartet. Die ManageViews speichern jetzt welches Objekt editiert wird. Das wird im EditHandler gesetzte. Im SaveHandler wird überprüft ob ein Objekt editiert wurde (getEditedVM != null). Das alte VM wird entfernt und durch das neue ersetzt. Hatte das alte VM einen anderen Namen, wird es aus dem ModelProvider entfernt und die dazugehörige .json gelöscht. Hat es den gleichen Namen wurde es überschrieben.

3: Hat man eine View zum Erstllen eines neuen VMObjekts vom Hauptfenster aus geöffnet, hat sie sich beim Klicken auf "fertig" nicht geschlossen.