### PR TITLE
Parameter im Model mit parseInteger und parseDouble parsen

### DIFF
--- a/Implementierung/src/main/java/de/sswis/model/algorithms/adaptation/RankPercentage.java
+++ b/Implementierung/src/main/java/de/sswis/model/algorithms/adaptation/RankPercentage.java
@@ -50,7 +50,7 @@ public class RankPercentage implements AdaptationAlgorithm {
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        percentage = (int)parameters.get("Percentage");
+        percentage = Integer.parseInt((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/algorithms/pairing/BruteForcePairingHeuristic.java
+++ b/Implementierung/src/main/java/de/sswis/model/algorithms/pairing/BruteForcePairingHeuristic.java
@@ -83,7 +83,7 @@ public class BruteForcePairingHeuristic implements PairingAlgorithm{
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        threshold = (double)parameters.get("Threshold");
+        threshold = Double.parseDouble((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/algorithms/ranking/AverageRank.java
+++ b/Implementierung/src/main/java/de/sswis/model/algorithms/ranking/AverageRank.java
@@ -125,7 +125,7 @@ public class AverageRank implements RankingAlgorithm {
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        windowSize = (int)parameters.get("Window size");
+        windowSize = Integer.parseInt((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/algorithms/ranking/CustomCycleScore.java
+++ b/Implementierung/src/main/java/de/sswis/model/algorithms/ranking/CustomCycleScore.java
@@ -64,7 +64,7 @@ public class CustomCycleScore implements RankingAlgorithm {
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        windowSize = (int)parameters.get("Window size");
+        windowSize = Integer.parseInt((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/conditions/Delta.java
+++ b/Implementierung/src/main/java/de/sswis/model/conditions/Delta.java
@@ -33,7 +33,7 @@ public class Delta implements Condition{
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        delta = (double)parameters.get("DELTA");
+        delta = Double.parseDouble((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/conditions/Probability.java
+++ b/Implementierung/src/main/java/de/sswis/model/conditions/Probability.java
@@ -33,7 +33,7 @@ public class Probability implements Condition {
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        alpha = (double)parameters.get("APLHA");
+        alpha = Double.parseDouble((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override

--- a/Implementierung/src/main/java/de/sswis/model/conditions/SpecificGroup.java
+++ b/Implementierung/src/main/java/de/sswis/model/conditions/SpecificGroup.java
@@ -29,7 +29,7 @@ public class SpecificGroup implements Condition {
 
     @Override
     public void setParameters(HashMap<String, Object> parameters) {
-        groupId = (int)parameters.get("GROUP_ID");
+        groupId = Integer.parseInt((String) parameters.get(PARAMETER_NAMES[0]));
     }
 
     @Override


### PR DESCRIPTION
Da man in der View nicht weiß welchen Datentypen die Parameter haben werden sie als String in die parameter HashMap geschrieben. Daher wäre es eigentlich besser gewesen eine `HashMap<String, String>` für die Parameter zu verwenden. Ich habe jetzt einfach im Model die Parameter mit `Integer.parseInt()` und `Double.parseDouble()` geparst, da das weniger Aufwand ist. 

Außerdem habe bei `parameters.get(PARAMETER_NAMES[0])` das Array mit den Namen verwendet, die Variante ist etwas schöner und weniger fehleranfällig. Bei einer Condition war der Parametername im String falsch geschrieben.