### PR TITLE
Initialization view impl

### DIFF
--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.form
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="f733c" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="f733c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="10" left="10" bottom="10" right="10"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
@@ -189,6 +189,14 @@
             </constraints>
             <properties>
               <text value="Label"/>
+            </properties>
+          </component>
+          <component id="dfcb1" class="javax.swing.JButton" binding="deleteButton">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="löschen"/>
             </properties>
           </component>
         </children>

--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.java
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.java
@@ -46,19 +46,20 @@ public class GroupTab {
     private JRadioButton percentageAgentCapitalRadioButton;
     private JFormattedTextField distributionTextField;
 
-    public GroupTab(List<String> allStrategies) {
+    public GroupTab() {
         this.vmGroup = new VMGroup();
-        this.allStrategies = allStrategies;
 
         strategyTabs = new ArrayList<InitialStrategyTab>();
+        allStrategies = new ArrayList<>();
         $$$setupUI$$$();
-        addStrategyTabs();
 
         startCapitalTabs = new ArrayList<StartCapitalTab>();
     }
 
 
-    private void addStrategyTabs() {
+    public void addStrategies(List<String> strategies) {
+        this.allStrategies.addAll(strategies);
+
         for (int i = 0; i < allStrategies.size(); i++) {
             InitialStrategyTab tab = new InitialStrategyTab(allStrategies.get(i));
 
@@ -117,24 +118,25 @@ public class GroupTab {
     public void setVMGroup(VMGroup vmGroup, boolean hasRelativeDist) {
         this.vmGroup = vmGroup;
 
-        groupIDLabel.setText(vmGroup.getId() + "");
         groupNameTextField.setText(vmGroup.getName());
 
-        //distributionTextField.setText(vmGroup.getAgents());
+        distributionTextField.setText(vmGroup.getAgentsString());
 
         percentageAgentStrategyRadioButton.setSelected(vmGroup.getRelativeStrategyDistributions());
         percentageAgentCapitalRadioButton.setSelected(vmGroup.getRelativeCapitalDistributions());
 
-        for (int i = 0; i < vmGroup.getStrategies().size(); i++) {
-            List<String> distribution = vmGroup.getStrategyDistributions().get(i);
-            //TODO: vm getter anpassen
-            //strategyTabs.get(i).setDistribution();
+        for (int i = 0; i < allStrategies.size(); i++) {
+
+
+            if (vmGroup.getStrategies().contains(allStrategies.get(i))) {
+                strategyTabs.get(i).setDistribution(vmGroup.getStrategyDistributionsStrings().get(i));
+            }
+
 
         }
 
         for (int i = 0; i < vmGroup.getStartCapital().size(); i++) {
-            //TODO: vm getter anpassen
-            //addSpecificCapital(vmGroup.getStartCapital().get(i), );
+            addSpecificCapital(vmGroup.getStartCapital().get(i), vmGroup.getStartCapitalDistributionsStrings().get(i));
         }
 
     }
@@ -146,6 +148,12 @@ public class GroupTab {
 
     public void setInitializationView(NewInitializationView initializationView) {
         this.initializationView = initializationView;
+    }
+
+    public void setID(int id) {
+        vmGroup.setId(id);
+        groupIDLabel.setText(vmGroup.getId() + "");
+
     }
 
     public void updateCapitalsTitle() {

--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.java
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.java
@@ -19,9 +19,6 @@ import java.util.List;
  */
 public class GroupTab {
 
-    private NewInitializationView initializationView;
-
-
     private VMGroup vmGroup;
     private List<String> allStrategies;
     private List<InitialStrategyTab> strategyTabs;
@@ -45,6 +42,7 @@ public class GroupTab {
     private JRadioButton idAgentCapitalRadioButton;
     private JRadioButton percentageAgentCapitalRadioButton;
     private JFormattedTextField distributionTextField;
+    private JButton deleteButton;
 
     public GroupTab() {
         this.vmGroup = new VMGroup();
@@ -86,6 +84,12 @@ public class GroupTab {
         capitalsTabbedPane.addTab(capitalTab.getTitle(), capitalTab.$$$getRootComponent$$$());
     }
 
+    public void removeCapitalTab(StartCapitalTab tab) {
+        capitalsTabbedPane.removeTabAt(startCapitalTabs.indexOf(tab));
+        startCapitalTabs.remove(tab);
+    }
+
+
     public void updateVM() {
 
         vmGroup.setName(groupNameTextField.getText());
@@ -104,13 +108,7 @@ public class GroupTab {
 
 
     public String getTitle() {
-        String title = vmGroup.getId() + ": ";
-
-        if (vmGroup.getName() == null) {
-            title = title + "unbenannt";
-        } else {
-            title = title + vmGroup.getName();
-        }
+        String title = groupIDLabel.getText() + ": " + groupNameTextField.getText();
 
         return title;
     }
@@ -146,14 +144,15 @@ public class GroupTab {
         return vmGroup;
     }
 
-    public void setInitializationView(NewInitializationView initializationView) {
-        this.initializationView = initializationView;
-    }
-
     public void setID(int id) {
         vmGroup.setId(id);
         groupIDLabel.setText(vmGroup.getId() + "");
 
+    }
+
+    public void setActionListener(NewInitializationView view) {
+        deleteButton.addActionListener(e -> view.removeGroupTab(this));
+        groupNameTextField.addActionListener(e -> view.updateGroupTabTitle());
     }
 
     public void updateCapitalsTitle() {
@@ -202,7 +201,7 @@ public class GroupTab {
         MainPanel = new JPanel();
         MainPanel.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(3, 2, new Insets(10, 10, 10, 10), -1, -1));
+        panel1.setLayout(new GridLayoutManager(4, 2, new Insets(10, 10, 10, 10), -1, -1));
         MainPanel.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         initGroupTabbedPane = new JTabbedPane();
         panel1.add(initGroupTabbedPane, new GridConstraints(2, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
@@ -258,6 +257,9 @@ public class GroupTab {
         panel1.add(groupNameTextField, new GridConstraints(1, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
         groupIDLabel.setText("Label");
         panel1.add(groupIDLabel, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        deleteButton = new JButton();
+        deleteButton.setText("löschen");
+        panel1.add(deleteButton, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     }
 
     /**

--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/StartCapitalTab.form
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/StartCapitalTab.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="68596" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="68596" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="10" left="10" bottom="10" right="10"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
@@ -76,6 +76,19 @@
             </constraints>
             <properties/>
           </component>
+          <component id="1142f" class="javax.swing.JButton" binding="deleteButton">
+            <constraints>
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="löschen"/>
+            </properties>
+          </component>
+          <vspacer id="d8a2f">
+            <constraints>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </vspacer>
         </children>
       </grid>
     </children>

--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/StartCapitalTab.java
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/StartCapitalTab.java
@@ -21,6 +21,7 @@ public class StartCapitalTab {
 
     private JLabel idLabel;
     private JFormattedTextField distributionTextField;
+    private JButton deleteButton;
 
     public StartCapitalTab() {
         $$$setupUI$$$();
@@ -51,6 +52,8 @@ public class StartCapitalTab {
         startCapitalTextField.addActionListener(e -> {
             groupTab.updateCapitalsTitle();
         });
+
+        deleteButton.addActionListener(e -> groupTab.removeCapitalTab(this));
     }
 
     private void createUIComponents() {
@@ -68,7 +71,7 @@ public class StartCapitalTab {
         MainPanel = new JPanel();
         MainPanel.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(6, 2, new Insets(10, 10, 10, 10), -1, -1));
+        panel1.setLayout(new GridLayoutManager(8, 2, new Insets(10, 10, 10, 10), -1, -1));
         MainPanel.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         panel1.add(spacer1, new GridConstraints(5, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
@@ -90,6 +93,11 @@ public class StartCapitalTab {
         panel1.add(spacer2, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 20), null, null, 0, false));
         distributionTextField = new JFormattedTextField();
         panel1.add(distributionTextField, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
+        deleteButton = new JButton();
+        deleteButton.setText("löschen");
+        panel1.add(deleteButton, new GridConstraints(6, 1, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final Spacer spacer3 = new Spacer();
+        panel1.add(spacer3, new GridConstraints(7, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
     }
 
     /**

--- a/Implementierung/src/main/java/de/sswis/view/NewInitializationView.form
+++ b/Implementierung/src/main/java/de/sswis/view/NewInitializationView.form
@@ -15,7 +15,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="de80" layout-manager="GridLayoutManager" row-count="14" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="de80" layout-manager="GridLayoutManager" row-count="16" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="10" right="10"/>
             <constraints/>
             <properties/>
@@ -39,7 +39,7 @@
               </component>
               <component id="38b64" class="javax.swing.JSeparator">
                 <constraints>
-                  <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
               </component>
@@ -73,14 +73,14 @@
               </component>
               <vspacer id="4a7d">
                 <constraints>
-                  <grid row="13" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                  <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
                     <minimum-size width="-1" height="20"/>
                   </grid>
                 </constraints>
               </vspacer>
               <tabbedpane id="25746" binding="groupTabbedPane">
                 <constraints>
-                  <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="14" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="200" height="200"/>
                   </grid>
                 </constraints>
@@ -90,7 +90,7 @@
               </tabbedpane>
               <component id="7c7f3" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <font size="16"/>
@@ -99,14 +99,14 @@
               </component>
               <vspacer id="bd34e">
                 <constraints>
-                  <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                  <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
                     <minimum-size width="-1" height="300"/>
                   </grid>
                 </constraints>
               </vspacer>
               <component id="a87e9" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Beschreibung (Dient nur zur Wiedererkennung und kann leer gelassen werden.) :"/>
@@ -114,7 +114,7 @@
               </component>
               <component id="5bf88" class="javax.swing.JTextPane" binding="descriptionTextPane">
                 <constraints>
-                  <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                  <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="50"/>
                   </grid>
                 </constraints>
@@ -122,14 +122,14 @@
               </component>
               <vspacer id="e4cea">
                 <constraints>
-                  <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                  <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
                     <minimum-size width="-1" height="10"/>
                   </grid>
                 </constraints>
               </vspacer>
               <component id="4f75" class="javax.swing.JButton" binding="addGroupButton" custom-create="true">
                 <constraints>
-                  <grid row="9" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="11" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Gruppe hinzufügen"/>
@@ -145,7 +145,7 @@
               </component>
               <component id="806b" class="javax.swing.JRadioButton" binding="idAgentGroupRadioButton" custom-create="true">
                 <constraints>
-                  <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <selected value="true"/>
@@ -154,12 +154,27 @@
               </component>
               <component id="4a6cc" class="javax.swing.JRadioButton" binding="percentageAgentGroupRadioButton" custom-create="true">
                 <constraints>
-                  <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="13" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <text value="Wähle Agenten nach prozentualem Anteil"/>
                 </properties>
               </component>
+              <component id="c0372" class="javax.swing.JCheckBox" binding="useCapitalCheckBox">
+                <constraints>
+                  <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Startkapital nur für Strategiebestimmung nutzen"/>
+                </properties>
+              </component>
+              <vspacer id="f9b6c">
+                <constraints>
+                  <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+                    <minimum-size width="-1" height="10"/>
+                  </grid>
+                </constraints>
+              </vspacer>
             </children>
           </grid>
         </children>

--- a/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
@@ -45,6 +45,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
     private ButtonGroup buttonGroup;
     private JRadioButton idAgentGroupRadioButton;
     private JRadioButton percentageAgentGroupRadioButton;
+    private JCheckBox useCapitalCheckBox;
 
     private AbstractManageInitializationsView parentView;
 
@@ -108,6 +109,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
 
         vmInitialization.setName(nameTextField.getText());
         vmInitialization.setAgentCount(Integer.parseInt(agentNumberTextField.getText()));
+        vmInitialization.setAddCapitalToTotalPoints(!useCapitalCheckBox.isSelected());
 
         for (int i = 0; i < groupTabs.size(); i++) {
             vmInitialization.addGroup(groupTabs.get(i).getVmGroup());
@@ -163,6 +165,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
         this.vmInitialization = initialization;
         nameTextField.setText(vmInitialization.getName());
         agentNumberTextField.setText(vmInitialization.getAgentCount() + "");
+        useCapitalCheckBox.setSelected(!vmInitialization.addCapitalToTotalPoints());
 
         percentageAgentGroupRadioButton.setSelected(vmInitialization.hasRelativeDistribution());
 
@@ -217,7 +220,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
         final JScrollPane scrollPane1 = new JScrollPane();
         panel1.add(scrollPane1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         final JPanel panel2 = new JPanel();
-        panel2.setLayout(new GridLayoutManager(14, 3, new Insets(10, 10, 10, 10), -1, -1));
+        panel2.setLayout(new GridLayoutManager(16, 3, new Insets(10, 10, 10, 10), -1, -1));
         scrollPane1.setViewportView(panel2);
         final JLabel label1 = new JLabel();
         label1.setText("Name :   ");
@@ -226,7 +229,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
         label2.setText("Anzahl der Agenten:");
         panel2.add(label2, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JSeparator separator1 = new JSeparator();
-        panel2.add(separator1, new GridConstraints(8, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+        panel2.add(separator1, new GridConstraints(10, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
         panel2.add(spacer1, new GridConstraints(2, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 10), null, null, 0, false));
         final Spacer spacer2 = new Spacer();
@@ -236,40 +239,45 @@ public class NewInitializationView implements AbstractNewInitializationView {
         final JSeparator separator2 = new JSeparator();
         panel2.add(separator2, new GridConstraints(1, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         final Spacer spacer3 = new Spacer();
-        panel2.add(spacer3, new GridConstraints(13, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 20), null, null, 0, false));
+        panel2.add(spacer3, new GridConstraints(15, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 20), null, null, 0, false));
         groupTabbedPane = new JTabbedPane();
-        panel2.add(groupTabbedPane, new GridConstraints(12, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(200, 200), null, 0, false));
+        panel2.add(groupTabbedPane, new GridConstraints(14, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(200, 200), null, 0, false));
         final JLabel label3 = new JLabel();
         Font label3Font = this.$$$getFont$$$(null, -1, 16, label3.getFont());
         if (label3Font != null) label3.setFont(label3Font);
         label3.setText("Gruppen");
-        panel2.add(label3, new GridConstraints(9, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel2.add(label3, new GridConstraints(11, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer4 = new Spacer();
-        panel2.add(spacer4, new GridConstraints(12, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 300), null, null, 0, false));
+        panel2.add(spacer4, new GridConstraints(14, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 300), null, null, 0, false));
         final JLabel label4 = new JLabel();
         label4.setText("Beschreibung (Dient nur zur Wiedererkennung und kann leer gelassen werden.) :");
-        panel2.add(label4, new GridConstraints(5, 1, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel2.add(label4, new GridConstraints(7, 1, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         descriptionTextPane = new JTextPane();
-        panel2.add(descriptionTextPane, new GridConstraints(6, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, new Dimension(150, 50), null, 0, false));
+        panel2.add(descriptionTextPane, new GridConstraints(8, 1, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_WANT_GROW, null, new Dimension(150, 50), null, 0, false));
         final Spacer spacer5 = new Spacer();
-        panel2.add(spacer5, new GridConstraints(7, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 10), null, null, 0, false));
+        panel2.add(spacer5, new GridConstraints(9, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 10), null, null, 0, false));
         addGroupButton.setText("Gruppe hinzufügen");
-        panel2.add(addGroupButton, new GridConstraints(9, 2, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel2.add(addGroupButton, new GridConstraints(11, 2, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         nameTextField = new JFormattedTextField();
         panel2.add(nameTextField, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
         idAgentGroupRadioButton.setSelected(true);
         idAgentGroupRadioButton.setText("Wähle Agenten nach ihren IDs");
-        panel2.add(idAgentGroupRadioButton, new GridConstraints(10, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel2.add(idAgentGroupRadioButton, new GridConstraints(12, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         percentageAgentGroupRadioButton.setText("Wähle Agenten nach prozentualem Anteil");
-        panel2.add(percentageAgentGroupRadioButton, new GridConstraints(11, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        panel2.add(percentageAgentGroupRadioButton, new GridConstraints(13, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        useCapitalCheckBox = new JCheckBox();
+        useCapitalCheckBox.setText("Startkapital nur für Strategiebestimmung nutzen");
+        panel2.add(useCapitalCheckBox, new GridConstraints(5, 1, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final Spacer spacer6 = new Spacer();
+        panel2.add(spacer6, new GridConstraints(6, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(-1, 10), null, null, 0, false));
         final JPanel panel3 = new JPanel();
         panel3.setLayout(new GridLayoutManager(1, 3, new Insets(10, 10, 10, 10), -1, -1));
         panel1.add(panel3, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         finishButton = new JButton();
         finishButton.setText("Fertig");
         panel3.add(finishButton, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        final Spacer spacer6 = new Spacer();
-        panel3.add(spacer6, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
+        final Spacer spacer7 = new Spacer();
+        panel3.add(spacer7, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, 1, null, null, null, 0, false));
         cancelButton = new JButton();
         cancelButton.setText("Abbrechen");
         panel3.add(cancelButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));

--- a/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
@@ -56,19 +56,24 @@ public class NewInitializationView implements AbstractNewInitializationView {
     }
 
     private void addNewGroupTab() {
-        GroupTab tab = new GroupTab(strategies);
+        GroupTab tab = new GroupTab();
+        tab.addStrategies(strategies);
         tab.setInitializationView(this);
 
+        tab.setID(groupTabbedPane.getTabCount());
         groupTabs.add(tab);
         groupTabbedPane.addTab(tab.getTitle(), tab.$$$getRootComponent$$$());
     }
 
     private void addSpecificGroupTab(VMGroup vmGroup) {
-        GroupTab tab = new GroupTab(strategies);
+        GroupTab tab = new GroupTab();
+        tab.addStrategies(strategies);
 
         tab.setInitializationView(this);
+
         tab.setVMGroup(vmGroup, percentageAgentGroupRadioButton.isSelected());
 
+        tab.setID(groupTabbedPane.getTabCount());
         groupTabs.add(tab);
         groupTabbedPane.addTab(tab.getTitle(), tab.$$$getRootComponent$$$());
     }
@@ -139,6 +144,9 @@ public class NewInitializationView implements AbstractNewInitializationView {
 
         this.vmInitialization = initialization;
         nameTextField.setText(vmInitialization.getName());
+        agentNumberTextField.setText(vmInitialization.getAgentCount() + "");
+
+        percentageAgentGroupRadioButton.setSelected(vmInitialization.hasRelativeDistribution());
 
         for (int i = 0; i < vmInitialization.getGroups().size(); i++) {
             addSpecificGroupTab(vmInitialization.getGroups().get(i));
@@ -166,6 +174,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
 
         percentageAgentGroupRadioButton = new JRadioButton();
         buttonGroup.add(percentageAgentGroupRadioButton);
+
 
     }
 

--- a/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
@@ -58,18 +58,36 @@ public class NewInitializationView implements AbstractNewInitializationView {
     private void addNewGroupTab() {
         GroupTab tab = new GroupTab();
         tab.addStrategies(strategies);
-        tab.setInitializationView(this);
+        tab.setActionListener(this);
 
         tab.setID(groupTabbedPane.getTabCount());
         groupTabs.add(tab);
         groupTabbedPane.addTab(tab.getTitle(), tab.$$$getRootComponent$$$());
     }
 
+    public void removeGroupTab(GroupTab tab) {
+
+        groupTabbedPane.removeTabAt(groupTabs.indexOf(tab));
+        groupTabs.remove(tab);
+
+        for (int i = 0; i < groupTabs.size(); i++) {
+            groupTabs.get(i).setID(i);
+            groupTabbedPane.setTitleAt(i, groupTabs.get(i).getTitle());
+        }
+    }
+
+    public void updateGroupTabTitle() {
+        for (int i = 0; i < groupTabs.size(); i++) {
+            groupTabbedPane.setTitleAt(i, groupTabs.get(i).getTitle());
+
+        }
+    }
+
     private void addSpecificGroupTab(VMGroup vmGroup) {
         GroupTab tab = new GroupTab();
         tab.addStrategies(strategies);
 
-        tab.setInitializationView(this);
+        tab.setActionListener(this);
 
         tab.setVMGroup(vmGroup, percentageAgentGroupRadioButton.isSelected());
 

--- a/Implementierung/src/main/java/de/sswis/view/model/VMGroup.java
+++ b/Implementierung/src/main/java/de/sswis/view/model/VMGroup.java
@@ -75,6 +75,9 @@ public class VMGroup {
 
     public List<String> getStrategyDistributionsStrings() { return this.strategyDistributions; }
 
+    public List<String> getStartCapitalDistributionsStrings() { return this.startCapitalDistributions; }
+
+
     public void addStrategy(String name, String distribution) {
         this.strategies.add(name);
         this.strategyDistributions.add(distribution);

--- a/Implementierung/src/main/java/de/sswis/view/model/VMInitialization.java
+++ b/Implementierung/src/main/java/de/sswis/view/model/VMInitialization.java
@@ -17,6 +17,8 @@ public class VMInitialization {
     private int numberOfInstances;
     private boolean relativeDistribution;
 
+    private boolean CapitalToTotalPoints;
+
     public VMInitialization() {
         name = "";
         groups = new ArrayList<>();
@@ -72,6 +74,14 @@ public class VMInitialization {
 
     public boolean hasRelativeDistribution() {
         return this.relativeDistribution;
+    }
+
+    public boolean addCapitalToTotalPoints() {
+        return CapitalToTotalPoints;
+    }
+
+    public void setAddCapitalToTotalPoints(boolean capitalToTotalPoints) {
+        CapitalToTotalPoints = capitalToTotalPoints;
     }
 }
 


### PR DESCRIPTION
- Fehler beim speichern laden der VMInitialisierung behoben
- Die GruppenID entspricht jetzt immer dem Tab Index
- Gruppen- und Startkapitaltabs können gelöscht werden
- beim drücken von Enter beim Gruppenname-, Startkapital Textfeldes wird der Tabtitel aktualisiert
- Die NewInitializationView hat eine Checkbox um Startkapital nur für Strategiebestimmung zu nutzen
und VMInitialization hat entsprechendes Attribut