### PR TITLE
Runden Initialisierung korrigiert

### DIFF
--- a/Implementierung/src/main/java/de/sswis/model/Configuration.java
+++ b/Implementierung/src/main/java/de/sswis/model/Configuration.java
@@ -44,10 +44,10 @@ public class Configuration {
         this.adaptationAlg = adaptation;
         this.pairingAlg = pairing;
         this.rankingAlg = ranking;
-        this.rounds = rounds;
+        this.rounds = rounds * cycles;
         this.cycles = cycles;
         this.adaptationProbability = adaptationProbability;
-        this.cycleRoundCount = rounds/cycles;
+        this.cycleRoundCount = rounds;
   }
 
     public String getName() {


### PR DESCRIPTION
Die Eingabe ist rounds (= Runden pro Zyklus) und cycles (=maximale Rundenanzahl). In der Simulation wird rounds als maximale Rundenanzahl interpretiert und cycleRoundCount als Runden pro Zyklus.