### PR TITLE
Einige Fehler bei der Eingabevalidierung behoben

### DIFF
--- a/Implementierung/src/main/java/de/sswis/util/InputValidator.java
+++ b/Implementierung/src/main/java/de/sswis/util/InputValidator.java
@@ -18,7 +18,7 @@ public class InputValidator {
      * @return {@code true}, wenn str ein gültiger Name ist, {@code false} sonst
      */
     public static boolean isLegalName(String str) {
-        return str.matches("[a-zA-Z][a-zA-Z0-9]{0,34}");
+        return str.matches("^(?! )[a-zA-Z0-9 ]{1,35}(?<! )$");
     }
 
     /**

--- a/Implementierung/src/main/java/de/sswis/util/InputValidator.java
+++ b/Implementierung/src/main/java/de/sswis/util/InputValidator.java
@@ -18,8 +18,7 @@ public class InputValidator {
      * @return {@code true}, wenn str ein gültiger Name ist, {@code false} sonst
      */
     public static boolean isLegalName(String str) {
-
-        return (str.matches("\\w{1,35}"));
+        return str.matches("[a-zA-Z][a-zA-Z0-9]{0,34}");
     }
 
     /**
@@ -31,7 +30,7 @@ public class InputValidator {
      */
     public static boolean isLegalDescription(String str) {
 
-        return (str.length() <= 140);
+        return (str.length() <= 300);
     }
 
     /**
@@ -117,6 +116,27 @@ public class InputValidator {
         return start != end;
     }
 
+    public static boolean isSingelOrMultiplePercantage(String input) {
+        if (input.contains("-")) {
+            // Variabler Parameter
+            String[] parts = input.split(" - ");
+            if (!(parts.length == 3))
+                return false;
+            if ( !(isSingleValue(parts[0]) && isSingleValue(parts[1]) && isSingleValue(parts[2])) )
+                return false;
+            int start = Integer.parseInt(parts[0]);
+            int end = Integer.parseInt(parts[1]);
+            int step = Integer.parseInt(parts[2]);
+
+            return start != end && start >= 0 && end >= 0 && start <= 100 && end <= 100 && step > 0 && step <= 100;
+        } else {
+            // Einfacher Parameter
+            if (!isSingleValue(input)) return false;
+            int percentage = Integer.parseInt(input);
+            return percentage >= 0 && percentage <= 100;
+        }
+    }
+
     public static boolean isPercentage(String str) {
 
         if (!(str.contains("%"))) return false;
@@ -131,6 +151,13 @@ public class InputValidator {
         int percentage = Integer.parseInt(str.trim());
 
         return (percentage > 0) && (percentage < 101);
+    }
+
+    public static boolean isProbability(String input) {
+        if (!isDouble(input))
+            return false;
+        double value = Double.parseDouble(input);
+        return 0 <= value && value <= 1;
     }
 
     public static boolean containsFamilyOfValues(String str) {

--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.java
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/GroupTab.java
@@ -138,9 +138,9 @@ public class GroupTab {
         vmGroup = new VMGroup();
 
         boolean relStrat = percentageAgentStrategyRadioButton.isSelected();
-        double stratPercentageSum = 0.0;
+        double stratPercentageSum = 1.0;
         boolean relCapital = percentageAgentCapitalRadioButton.isSelected();
-        double capitalPercentageSum = 0.0;
+        double capitalPercentageSum = 1.0;
 
         if (strategyTabs.size() == 0 || startCapitalTabs.size() == 0) return false;
 
@@ -150,9 +150,10 @@ public class GroupTab {
         vmGroup.setRelativeStrategyDistribution(relStrat);
         for (int i = 0; i < strategyTabs.size(); i++) {
             String distr = strategyTabs.get(i).getUserInput();
-            if ((relStrat && isDouble(distr)) || (!relStrat && isIntervalPlusSingleValues(distr))) {
+            if ((relStrat && isSingelOrMultiplePercantage(distr)) || (!relStrat && isIntervalPlusSingleValues(distr))) {
                 vmGroup.addStrategy(strategyTabs.get(i).getTitle(), distr);
-                if (relStrat) stratPercentageSum += Double.parseDouble(distr);
+                // Funktioniert nicht für variable Parameter
+                //if (relStrat) stratPercentageSum += Double.parseDouble(distr);
             }
             else return false;
         }
@@ -162,9 +163,10 @@ public class GroupTab {
             String capital = startCapitalTabs.get(i).getStartCapital();
             String distr = startCapitalTabs.get(i).getAgentUserInput();
             if (isSingleValue(capital) &&
-                    ((relCapital && isDouble(distr)) || (!relCapital && isIntervalPlusSingleValues(distr)))) {
+                    ((relCapital && isSingelOrMultiplePercantage(distr)) || (!relCapital && isIntervalPlusSingleValues(distr)))) {
                 vmGroup.addStartCapital(capital, distr);
-                if (relCapital) capitalPercentageSum += Double.parseDouble(distr);
+                // Funktioniert nicht für variable Parameter
+                //if (relCapital) capitalPercentageSum += Double.parseDouble(distr);
             }
             else return false;
         }

--- a/Implementierung/src/main/java/de/sswis/view/CustomComponents/ParameterTable.java
+++ b/Implementierung/src/main/java/de/sswis/view/CustomComponents/ParameterTable.java
@@ -61,10 +61,6 @@ public class ParameterTable {
 
     }
 
-    public Object returnString() {
-        return "Hallo";
-    }
-
     public HashMap<String, Object> getAllUserInputs() {
         HashMap<String, Object> params = new HashMap<>();
 

--- a/Implementierung/src/main/java/de/sswis/view/NewCombinedStrategyView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewCombinedStrategyView.java
@@ -179,8 +179,7 @@ public class NewCombinedStrategyView implements AbstractNewCombinedStrategyView 
 
             vmCombinedStrategy.setDescription(desc);
             return true;
-        }
-        else {
+        } else {
             JOptionPane.showMessageDialog(frame, ILLEGAL_INPUT_MSG);
             return false;
         }

--- a/Implementierung/src/main/java/de/sswis/view/NewConfigurationView.form
+++ b/Implementierung/src/main/java/de/sswis/view/NewConfigurationView.form
@@ -107,6 +107,7 @@
                 </constraints>
                 <properties>
                   <text value="Anzahl der Runden"/>
+                  <toolTipText value="Eine ganze Zahl größer als 0."/>
                 </properties>
               </component>
               <component id="3d6f7" class="javax.swing.JLabel">
@@ -117,6 +118,7 @@
                 </constraints>
                 <properties>
                   <text value="Maximale Anzahl der Zyklen"/>
+                  <toolTipText value="Eine ganze Zahl größer als 0."/>
                 </properties>
               </component>
               <component id="93935" class="javax.swing.JTextField" binding="roundsTextField">
@@ -167,6 +169,7 @@
                 </constraints>
                 <properties>
                   <text value="Name"/>
+                  <toolTipText value="Der Name muss mit einem Buchstaben beginnen, darf nur alphanumerische Zeichen beinhalten und maximal 35 Zeichen lang sein."/>
                 </properties>
               </component>
               <component id="1d734" class="javax.swing.JFormattedTextField" binding="nameTextField">

--- a/Implementierung/src/main/java/de/sswis/view/NewConfigurationView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewConfigurationView.java
@@ -4,13 +4,12 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
 import de.sswis.view.CustomComponents.ParameterTable;
-import de.sswis.view.model.*;
+import de.sswis.view.model.VMConfiguration;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.EventListener;
 import java.util.HashMap;
 import java.util.List;
 
@@ -105,7 +104,7 @@ public class NewConfigurationView implements AbstractNewConfigurationView {
         String cycles = cyclesTextField.getText();
 
         if (!(isSingleValue(rounds) && Integer.parseInt(rounds) > 0) ||
-                !(isSingleValue(cycles) && Integer.parseInt(cycles) > 0) || !(isInPercentageRange(adaptProb))) {
+                !(isSingleValue(cycles) && Integer.parseInt(cycles) > 0) || !(isProbability(adaptProb))) {
             JOptionPane.showMessageDialog(frame, ILLEGAL_INPUT_MSG);
             return false;
         }

--- a/Implementierung/src/main/java/de/sswis/view/NewGameView.form
+++ b/Implementierung/src/main/java/de/sswis/view/NewGameView.form
@@ -128,6 +128,7 @@
             </constraints>
             <properties>
               <text value="Beschreibung:"/>
+              <toolTipText value="Die Beschreibung darf maximal 300 Zeichen lang sein."/>
             </properties>
           </component>
           <component id="1234" class="javax.swing.JTextPane" binding="descriptionPane">
@@ -144,6 +145,7 @@
             </constraints>
             <properties>
               <text value="Name: "/>
+              <toolTipText value="Der Name muss mit einem Buchstaben beginnen, darf nur alphanumerische Zeichen beinhalten und maximal 35 Zeichen lang sein."/>
             </properties>
           </component>
           <component id="acf37" class="javax.swing.JLabel" binding="upRightPayOffLabel" custom-create="true">

--- a/Implementierung/src/main/java/de/sswis/view/NewInitializationView.form
+++ b/Implementierung/src/main/java/de/sswis/view/NewInitializationView.form
@@ -27,6 +27,7 @@
                 </constraints>
                 <properties>
                   <text value="Name :   "/>
+                  <toolTipText value="Der Name muss mit einem Buchstaben beginnen, darf nur alphanumerische Zeichen beinhalten und maximal 35 Zeichen lang sein."/>
                 </properties>
               </component>
               <component id="5873c" class="javax.swing.JLabel">
@@ -35,6 +36,7 @@
                 </constraints>
                 <properties>
                   <text value="Anzahl der Agenten:"/>
+                  <toolTipText value="Eine gerade ganze Zahl größer als 0."/>
                 </properties>
               </component>
               <component id="38b64" class="javax.swing.JSeparator">
@@ -110,6 +112,7 @@
                 </constraints>
                 <properties>
                   <text value="Beschreibung (Dient nur zur Wiedererkennung und kann leer gelassen werden.) :"/>
+                  <toolTipText value="Die Beschreibung darf maximal 300 Zeichen lang sein."/>
                 </properties>
               </component>
               <component id="5bf88" class="javax.swing.JTextPane" binding="descriptionTextPane">

--- a/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewInitializationView.java
@@ -115,7 +115,7 @@ public class NewInitializationView implements AbstractNewInitializationView {
         String name = nameTextField.getText();
         String desc = descriptionTextPane.getText();
         boolean relDistr = percentageAgentGroupRadioButton.isSelected();
-        double percentageSum = 0.0;
+        double percentageSum = 1.0;
 
         boolean illegalInput = false;
 
@@ -129,19 +129,26 @@ public class NewInitializationView implements AbstractNewInitializationView {
             for (int i = 0; i < groupTabs.size(); i++) {
                 VMGroup currentGroup = groupTabs.get(i).getVmGroup();
 
-                if (currentGroup != null &&
-                        ((relDistr && isDouble(currentGroup.getAgentsString()))
-                                || (!relDistr && isIntervalPlusSingleValues(currentGroup.getAgentsString())))) {
+                if (currentGroup != null
+                        && ( (relDistr && isSingelOrMultiplePercantage(currentGroup.getAgentsString()))
+                            || (!relDistr && isIntervalPlusSingleValues(currentGroup.getAgentsString())) )
+                ) {
                     vmInitialization.addGroup(currentGroup);
-                    if (relDistr) percentageSum += Double.parseDouble(currentGroup.getAgentsString());
+                    // Funktioniert so nicht für variable Parameter
+                    // if (relDistr) {
+                    //    percentageSum += Double.parseDouble(currentGroup.getAgentsString());
+                    // }
                 } else {
                     illegalInput = true;
                     break;
                 }
             }
-            if (relDistr && percentageSum != 1.0) illegalInput = true;
+            if (relDistr && percentageSum != 1.0) {
+                illegalInput = true;
+            }
+        } else {
+            illegalInput = true;
         }
-        else illegalInput = true;
 
         if (illegalInput) {
             JOptionPane.showMessageDialog(frame, ILLEGAL_INPUT_MSG);

--- a/Implementierung/src/main/java/de/sswis/view/NewStrategyView.java
+++ b/Implementierung/src/main/java/de/sswis/view/NewStrategyView.java
@@ -110,7 +110,7 @@ public class NewStrategyView implements AbstractNewStrategyView {
                 String currentPercentage = probabilityTextFields.get(i).getText();
                 vmStrategy.addStrategy(currentStrategy,
                         currentPercentage);
-                if (!isDouble(currentPercentage) || currentStrategy == null) {
+                if (!isProbability(currentPercentage) || currentStrategy == null) {
                     illegalInput = true;
                     break;
                 }


### PR DESCRIPTION
Namen müssen dem Regex [a-zA-Z][a-z-A-Z0-9]{0,34} entsprechen (darf keine '_' enthalten).
Beschreibungen dürfen maximal 300 Zeichen lang sein.
Anpassungswahrscheinlichkeit muss im Intervall [0;1] liegen.
Wahrscheinlichkeiten bei den gemischten Strategien müssen im Intervall [0;1] liegen.
Variable Parameter bei Initialisierung für prozentuale Angaben (wurde vorher nicht erlaubt).